### PR TITLE
Handle case for blank details for country

### DIFF
--- a/lib/google-contacts/element.rb
+++ b/lib/google-contacts/element.rb
@@ -147,7 +147,8 @@ module GContacts
         new_address['geo_city']     = address['gd:city']
         new_address['geo_state']    = address['gd:region']
         new_address['zipcode']      = address['gd:postcode']
-        new_address['country']      = address['gd:country']
+        country = address['gd:country']
+        new_address['country']      = country.is_a?(Hash) ? nil : country
         unless address['@rel'].nil?
           new_address['type'] = get_google_label_name(address['@rel'])
         else

--- a/lib/google-contacts/element.rb
+++ b/lib/google-contacts/element.rb
@@ -148,7 +148,7 @@ module GContacts
         new_address['geo_state']    = address['gd:region']
         new_address['zipcode']      = address['gd:postcode']
         country = address['gd:country']
-        new_address['country']      = country.is_a?(Hash) ? nil : country
+        new_address['country']      = country.is_a?(String) ? country : nil
         unless address['@rel'].nil?
           new_address['type'] = get_google_label_name(address['@rel'])
         else

--- a/spec/responses/contacts/contact_with_all_data.xml
+++ b/spec/responses/contacts/contact_with_all_data.xml
@@ -45,6 +45,7 @@
     <gd:street>Nokia Limia 720</gd:street>
     <gd:city>Finland</gd:city>
     <gd:region>Earth</gd:region>
+    <gd:country code="US"></gd:country>
   </gd:structuredPostalAddress>
   <gContact:birthday when='1989-09-10'/> <!-- Format is YYYY-MM-DD -->
   <gContact:event label='Birthday'>


### PR DESCRIPTION
Hello Team,

This PR handle case for blank details for country

Earlier `<gd:country code='US'></gd:country>` converted to `{"country"=>{"@code"=>"US"}}`
Now `<gd:country code='US'></gd:country>` convert to `{"country"=>nil}`

Please review and advice.

Thanks